### PR TITLE
Revert "Update reqwest requirement from 0.10 to 0.11"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 clap = "3.1.12"
 
 [dependencies]
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 tokio = { version = "1.17", features = ["full"] }
 serde = { version = "1.0.55", features = ["derive"] }
 openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
Reverts HurricaneLabs/CLI-Wrapper-for-AppInspect-API#23 - breaking change